### PR TITLE
Small fixes for BotW and Tales of Vesperia (#106)

### DIFF
--- a/Cheats/README.md
+++ b/Cheats/README.md
@@ -168,7 +168,7 @@ There might be a cheat in the database but not listed here!
 ### T
 |Name|TitleID|Region
 |--|--|--
-|Tales of Vesperia|[01002C0008E52000](01002C0008E52000)|![WLD](http://nswdb.com/images/WLD.jpg)
+|Tales of Vesperia|[01002C0008E52000](01002C0008E52000/cheats)|![WLD](http://nswdb.com/images/WLD.jpg)
 |TENGAI|[0100B2600A398000](0100B2600A398000/cheats)|![WLD](http://nswdb.com/images/WLD.jpg)
 |The Legend of Zelda: Breath of the Wild|[01007EF00011E000](01007EF00011E000/cheats)|![WLD](http://nswdb.com/images/WLD.jpg)
 |The Messenger|[0100DC300AC78000](0100DC300AC78000/cheats)|![WLD](http://nswdb.com/images/WLD.jpg)

--- a/Configs/01007EF00011E000.json
+++ b/Configs/01007EF00011E000.json
@@ -2,7 +2,7 @@
 	"author": "borntohonk & macia10",
 	"scriptLanguage": "lua",
 	"beta": false,
-	"1.5.0": [
+	"1.6.0": [
 		{
 			"saveFilePaths": ["\\d"],
 			"files": "game_data\\.sav",


### PR DESCRIPTION
* Updates Readme.md for cheats so Tales of Vesperia is redirected correctly.

* Updated The Legend of Zelda: Breath of the Wild config file to make it compatible with most current version 1.6.